### PR TITLE
Use `match` instead of `if`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,12 @@
 extern crate chrono;
 extern crate libc;
 
-use chrono::Timelike;
+use std::cmp::Ordering::*;
+
+use chrono::datetime::DateTime;
+use chrono::offset::utc::UTC;
+use chrono::duration::Duration;
+
 
 fn main() {
     // TODO: argument parsing
@@ -22,15 +27,13 @@ fn main() {
     }
 }
 
-type UTCTime = chrono::datetime::DateTime<chrono::offset::utc::UTC>;
-
 struct Countdown {
     /// The power word used to end the countdown
     liftoff: String,
     /// When the countdown ends
-    deadline: UTCTime,
+    deadline: DateTime<UTC>,
     /// Final countdown
-    countdown: i8
+    countdown: u8
 }
 
 enum Mark {
@@ -39,11 +42,12 @@ enum Mark {
     Liftoff(String)
 }
 
+use Mark::*;
+
 /// Default is: 3...2...1...Go!
 impl Default for Countdown {
     fn default() -> Countdown {
-        let t = chrono::offset::utc::UTC::now()
-              + chrono::duration::Duration::minutes(2);
+        let t = UTC::now() + Duration::minutes(2) + Duration::milliseconds(10);
         Countdown { liftoff: "Go!".to_string(), deadline: t, countdown: 3 }
     }
 }
@@ -58,22 +62,23 @@ impl Iterator for Countdown {
         let mut rem = SecondsAndNanos{tv_sec: 0, tv_nsec: 0};
 
         loop {
-            let t = chrono::offset::utc::UTC::now();
+            let d = self.deadline - UTC::now();
             unsafe { libc::funcs::posix88::unistd::nanosleep(&req, &mut rem); }
 
-            if t.timestamp() == self.deadline.timestamp() {
-                return Some(Mark::Liftoff(self.liftoff.clone()));
-            } else if t > self.deadline {
-                return None
-            } else if t.time().second() == self.deadline.time().second() &&
-                      t.time().minute() < self.deadline.time().minute() {
-                let m = self.deadline.time().minute() - t.time().minute();
-                return Some(Mark::Minute(m));
-            } else if self.deadline.minute() == t.time().minute() &&
-                      self.deadline.time().second() > t.time().second() &&
-                      self.deadline.time().second() - t.time().second() <= self.countdown as u32 {
-                let s = self.deadline.time().second() - t.time().second();
-                return Some(Mark::Second(s));
+            match (d.num_minutes().cmp(&1),
+                   d.num_seconds().cmp(&(self.countdown as i64)),
+                   d.num_seconds() % 60,
+                   d.num_seconds().cmp(&1),
+                   d.cmp(&Duration::seconds(0))) {
+                (Greater, _, 0, _, _) | (Equal, _, 0, _, _) =>
+                    return Some(Minute(d.num_minutes() as u32)),
+                (_, Equal, _, _, _) | (_, Less, _, Greater, _) |
+                (_, Less, _, Equal, _) =>
+                    return Some(Second(d.num_seconds() as u32)),
+                (_, _, _, _, Equal) | (_, _, _, Less, Greater) =>
+                    return Some(Liftoff(self.liftoff.clone())),
+                (_, _, _, _, Less) => return None,
+                (_, _, _, _, _)    => {}
             }
         }
     }


### PR DESCRIPTION
Offers clarity about what (and how many) comparisons are being performed and
comes with the added benefit of totality checking: removing the final case
results in:

  non-exhaustive patterns: `(Less, Greater, _, Equal, Greater)` not covered
